### PR TITLE
Unify rules and templates

### DIFF
--- a/wiki.moinmoin
+++ b/wiki.moinmoin
@@ -421,6 +421,9 @@ TODO: Review for Package: <TBD>
 TODO: WRITE - <TBD> The essence of the review result from the MIR POV
 TODO-A: MIR team ACK
 TODO-B: MIR team NACK
+TODO-C: MIR team ACK under the constraint to resolve the below listed
+TODO-C: required TODOs and as much as possible having a look at the
+TODO-C: recommended TODOs.
 TODO-A: This does need a security review, so I'll assign ubuntu-security
 TODO-B: This does not need a security review
 TODO: List of specific binary packages to be promoted to main: <TBD>


### PR DESCRIPTION
As discussed in the MIR team meetings, before we further mess with new rules we need to improve our current content. Weaknesses identified so far was "redundancy" and "Non-locality" in regard to templates and rules. This was true for both, the MIR-reporter and the MIR-reviewer sections.

We had cases where people missed to add expected statements because the rules were too far away from the template. And in other cases the template examples were better explanation than the rules.

Furthermore we also lacked quite some template entries. For the reporters we actually had none at all, just the headlines. Due to that often MIR-reporters were forgetting (or hiding intentionally) some actually required entries.

This overhaul and unification of rules and templates shall help with all that.
Overview of changes:
- Templates and Rules all follow a single style now
- The template approach was helpful to the MIR Team, so the reporters now got a fully populated one as well
- There is a how-to for the usage of those templates
- Requester: Unified Main Inclusion requirements (template) and Main Inclusion requirements (Rules) in one place
- Reviewer: Unified "Reviewing a bug" rules and "MIR review template" in one place
- Thereby we are removing plenty of redundancy (which often evolved slightly differently showing one of the common problems of redundancy)
- This also allowed to add various clarifications
- Added more guidance to what statements we expect to be present
