### PR TITLE
RFC: ensure package built in most recent archive test rebuild

### DIFF
--- a/wiki.moinmoin
+++ b/wiki.moinmoin
@@ -404,6 +404,12 @@ TODO-B:   alerted by the security team) commits to provide updates to the securi
 TODO-B:   team for any affected vendored code for the lifetime of the release
 TODO-B:   (including ESM).
 
+RULE: - if there has been an archive test rebuild that has occurred more recently
+RULE:   than the last upload, the package must have rebuilt successfully
+TODO-A: - The package has been built in the archive more recently than the last
+TODO-A:   test rebuild
+TODO-B: - The package successfully built during the most recent test rebuild
+
 [Background information]
 RULE: - The package descriptions should explain the general purpose and context
 RULE:   of the package. Additional explanations/justifications should be done in


### PR DESCRIPTION
[Since I can't file an issue/bug against the repo, I'm raising this by a pobably wrong-headed merge request]

Add a requirement that the source package under consideration successfully built in the most recent archive test rebuild, if the rebuild occurred more recently than the last upload of the package.

 A motivting example where this is an issue is the python-cheroot MIR:

  https://bugs.launchpad.net/ubuntu/+source/python-cheroot/+bug/1930111/

where the last upload for python-cheroot had occurred during impish, but during the jammy first test rebuild, the package failed to build due to some sort of hang that occurs during the build time tests. Having a package that goes into main but won't rebuild successfully is a problem for maintenance.

I wasn't quite sure which section this would make sense for, and also I wasn't sure if the mir reviewer should have a check for this added as well.